### PR TITLE
Fix NavLink

### DIFF
--- a/src/components/NavLink.jsx
+++ b/src/components/NavLink.jsx
@@ -4,7 +4,7 @@ const NavLink = ({ href, text }) => {
   return (
     <ReactRouterNavLink
       to={href}
-      className={({ isActive }) => isActive && "font-bold"}
+      className={({ isActive }) => isActive ? "font-bold" : undefined}
     >
       {text}
     </ReactRouterNavLink>


### PR DESCRIPTION
Fixes errors appearing on DevTools console due to boolean being passed into className when it expects a string